### PR TITLE
Changes for Windows compilation

### DIFF
--- a/packet-blip.c
+++ b/packet-blip.c
@@ -16,7 +16,7 @@
 #include <epan/conversation.h>
 
 #include <wiretap/wtap.h>
-#include <printf.h>
+#include <stdio.h>
 
 #include "packet-http.h"
 
@@ -258,7 +258,7 @@ dissect_blip(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *data)
         proto_tree_add_item(blip_tree, hf_blip_properties, tvb_child, 0, (guint) value_properties_length, ENC_UTF_8);
 
         // Bump the offset by the length of the properties
-        offset += value_properties_length;
+        offset += (gint)gvalue_properties_length;
         printf("new offset: %d\n", offset);
 
 
@@ -434,7 +434,7 @@ is_first_frame_in_msg(blip_conversation_entry_t *conversation_entry_ptr, packet_
     guint* first_frame_number_for_msg = wmem_map_lookup(conversation_entry_ptr->blip_requests, (void *) hash_key);
 
     if (first_frame_number_for_msg != NULL) {
-        printf("found first_frame_number:%d for_msg: %lu with hash key: %s\n", *first_frame_number_for_msg, value_message_num, hash_key);
+        printf("found first_frame_number:%d for_msg: %llu with hash key: %s\n", *first_frame_number_for_msg, (unsigned long long)value_message_num, hash_key);
         if (*first_frame_number_for_msg != pinfo->num) {
             printf("first_frame_in_msg = FALSE;");
             first_frame_in_msg = FALSE;


### PR DESCRIPTION
1. printf.h is not a header on Windows, use stdio.h

Cmake also treats all warnings as errors, and there are more of them in MSVC

1. += using 32-bit & 64-bit types causes potential unwanted shortening (261)
2. value_message_num is a 64-bit unsigned type on Windows / maybe Mac, but 32 bit on Linux so the correct printf format is "llu" and a cast is needed (437)

Didn't verify on