### PR TITLE
Adds compressed message support, among other things

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,4 @@ Build + Run.
 
 ## TODO
 
-1. Expand flags to be more readable (currently just shows decimal version)
-1. Handle compressed messages
 1. Submit this to the Wireshark Repo for being [included in Wireshark](https://www.wireshark.org/docs/wsdg_html_chunked/ChSrcContribute.html) by default


### PR DESCRIPTION
Also does the following
1. Correct renamed header
2. Add enum support for BLIP flags
3. Add the message number to the summary text of the message
4. Corrects the properties not being highlighted when selected in wireshark
5. Adds checksum field